### PR TITLE
Added L711 guide to main config, page, and navigation

### DIFF
--- a/landing/welcome.mdx
+++ b/landing/welcome.mdx
@@ -33,4 +33,6 @@ Whether you're a newcomer eager to learn the ropes or a seasoned member looking 
 
 # Have an idea for a guide?
 
-Leave a message by leaving a nudge via GeekyCowboy via Discord.
+We are confident that our hub is a place of immense potential, and we believe that every member, whether new or veteran, can help us bring out the best in it. That's why we encourage all members to create guides. 
+
+To learn more about creating guides, visit our "Guide Creation" page on the left navigation of our guide hub. Let's unleash the full potential of this hub together!

--- a/mint.json
+++ b/mint.json
@@ -69,7 +69,8 @@
         "group": "Locals",
         "pages": [
           "southeast/locals/L729",
-          "southeast/locals/L743"
+          "southeast/locals/L743",
+          "southeast/locals/L711"
         ]
       }
     ]

--- a/southeast/locals/L711.mdx
+++ b/southeast/locals/L711.mdx
@@ -2,7 +2,7 @@
 title: Local 711
 ---
 
-This route starts at Moncrief Yard in Jacksonville, Florida, and involves transporting a variety of cars to industries located on the southward part of the A-Line heading towards Pecan, Florida.
+This local originates at Moncrief Yard in Jacksonville, Florida, and involves transporting a variety of cars to industries located on the southward part of the A-Line where it ends in Pecan, Florida.
 
 In order to complete this local, please follow the steps below:
 

--- a/southeast/locals/L711.mdx
+++ b/southeast/locals/L711.mdx
@@ -1,0 +1,43 @@
+---
+title: Local 711
+---
+
+This route starts at Moncrief Yard in Jacksonville, Florida, and involves transporting a variety of cars to industries located on the southward part of the A-Line heading towards Pecan, Florida.
+
+In order to complete this local, please follow the steps below:
+
+<Steps>
+  <Step title="First Step">
+    Please find the assigned consist or locomotive that corresponds to the train symbol "L711". The last two digits of the train symbol represent the day of the month that the local is being worked on. For instance, if the local is operated on March 23rd, 2024, then the train symbol would be "L71123".
+  </Step>
+  <Step title="Second Step">
+    Before locating the cut of cars with the car symbols tag containing "L711", prepare the locomotive for operation.
+  </Step>
+  <Step title="Third Step">
+    To begin, locate your assigned cars and then move your locomotive to the yard track where your cars are located. 
+  </Step>
+    <Step title="Fourth Step">
+    After that, couple the cars to the locomotive, attach the brake hoses, and perform a thorough check of the train.
+  </Step>
+      <Step title="Fifth Step">
+    Then, follow the dispatchers instructions or signal indication that you have set (if no dispatches are online) to exit the yard and begin your journey.
+  </Step>
+    <Step title="Sixth Step">
+    After leaving the yard, your task is to deliver the cars that have been assigned to each industry. You can refer to the illustration guide provided below for the details. However, you may need to move some cars out of the industry tracks that were last worked on by L711.
+  </Step>
+      <Step title="Seventh Step">
+    After completing all industries, return to Moncrief Yard to return the locomotive to its origin yard, regardless of whether or not cars are available.
+  </Step>
+        <Step title="Eighth Step">
+    If you have brought any cars, please park them in the yard so that the yard crew can sort them for upcoming road trains.
+  </Step>
+</Steps>
+
+Looking for industries to operate in this area? Check out the illustration below.
+
+<Frame>
+  <img src="images/L711_Map_A-LINE_FRC_V1_Preview.jpg" />
+</Frame>
+
+We hope this guide helps you get the job done while enjoying Run 8 Train Simulator within Forever Rail! If you have any questions, please don't hesitate to ask.
+


### PR DESCRIPTION
This pull request includes the official guide for L711 along with a graphical illustration.

It also includes the adding of the guide to the hub's directory, navigation, and illustration to the images folder too. This pull request will be to check formatting and make sure it looks presentable before disabling public view.